### PR TITLE
Initialize FastAPI & React scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,174 +1,22 @@
-# Byte-compiled / optimized / DLL files
+# Python
 __pycache__/
 *.py[cod]
-*$py.class
-
-# C extensions
-*.so
-
-# Distribution / packaging
-.Python
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-share/python-wheels/
-*.egg-info/
-.installed.cfg
 *.egg
-MANIFEST
-
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.nox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*.cover
-*.py,cover
-.hypothesis/
-.pytest_cache/
-cover/
-
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-db.sqlite3-journal
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-.pybuilder/
-target/
-
-# Jupyter Notebook
-.ipynb_checkpoints
-
-# IPython
-profile_default/
-ipython_config.py
-
-# pyenv
-#   For a library or package, you might want to ignore these files since the code is
-#   intended to run in multiple environments; otherwise, check them in:
-# .python-version
-
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
-# UV
-#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#uv.lock
-
-# poetry
-#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
-#poetry.lock
-
-# pdm
-#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
-#pdm.lock
-#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
-#   in version control.
-#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
-.pdm.toml
-.pdm-python
-.pdm-build/
-
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
-__pypackages__/
-
-# Celery stuff
-celerybeat-schedule
-celerybeat.pid
-
-# SageMath parsed files
-*.sage.py
-
-# Environments
-.env
-.venv
+*.egg-info/
+.eggs/
+*.pyo
+*.pyd
+.Python
 env/
 venv/
 ENV/
-env.bak/
-venv.bak/
 
-# Spyder project settings
-.spyderproject
-.spyproject
+# Node
+node_modules/
+dist/
+build/
+.DS_Store
+*.log
 
-# Rope project settings
-.ropeproject
-
-# mkdocs documentation
-/site
-
-# mypy
-.mypy_cache/
-.dmypy.json
-dmypy.json
-
-# Pyre type checker
-.pyre/
-
-# pytype static type analyzer
-.pytype/
-
-# Cython debug symbols
-cython_debug/
-
-# PyCharm
-#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
-
-# Ruff stuff:
-.ruff_cache/
-
-# PyPI configuration file
-.pypirc
+# Local environment variables
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,78 @@
-# simple_form
+# Simple Form Project
+
+This repository contains a minimal scaffolding for a dynamic form system
+with a FastAPI backend and a React (TypeScript) frontend. The project is
+split into two parts:
+
+- **Form Builder** – allows creating and versioning forms.
+- **Form Runner** – renders forms for users to fill out.
+
+## Project Structure
+
+```
+backend/        FastAPI application
+  app/
+    db/         MongoDB connection utilities
+    routes/     Placeholder API routes
+    schemas/    Pydantic models
+  main.py       Application entrypoint
+  requirements.txt
+
+frontend/       React application powered by Vite
+  src/          React source files
+    App.tsx
+    main.tsx
+  index.html    Entry HTML file
+  package.json  Frontend dependencies
+  tsconfig*.json TypeScript configuration
+```
+
+## MongoDB Connection
+
+The backend uses **Motor** for asynchronous MongoDB access. Connection
+parameters are read from environment variables:
+
+- `MONGO_URI` – MongoDB connection string (default:
+  `mongodb://localhost:27017`)
+- `MONGO_DB_NAME` – database name (default: `simple_form`)
+
+## Running the Backend
+
+1. Create a virtual environment and install dependencies:
+
+   ```bash
+   cd backend
+   python3 -m venv env
+   source env/bin/activate
+   pip install -r requirements.txt
+   ```
+
+2. Start the FastAPI app:
+
+   ```bash
+   uvicorn main:app --reload
+   ```
+
+## Running the Frontend
+
+1. Install Node dependencies:
+
+   ```bash
+   cd frontend
+   npm install
+   ```
+
+2. Start the development server:
+
+   ```bash
+   npm run dev
+   ```
+
+The frontend will be available at `http://localhost:3000`.
+
+## Notes
+
+This project currently contains only placeholder routes and components.
+Additional logic for form creation, rendering and submission should be
+implemented in the respective backend and frontend folders.
+

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,2 @@
+# Placeholder for FastAPI application package
+

--- a/backend/app/db/__init__.py
+++ b/backend/app/db/__init__.py
@@ -1,0 +1,3 @@
+# MongoDB connection utilities
+from .mongodb import get_database
+

--- a/backend/app/db/mongodb.py
+++ b/backend/app/db/mongodb.py
@@ -1,0 +1,22 @@
+from motor.motor_asyncio import AsyncIOMotorClient
+import os
+
+MONGO_URI = os.getenv("MONGO_URI", "mongodb://localhost:27017")
+DATABASE_NAME = os.getenv("MONGO_DB_NAME", "simple_form")
+
+client: AsyncIOMotorClient | None = None
+
+def get_client() -> AsyncIOMotorClient:
+    assert client is not None, "Mongo client is not initialized"
+    return client
+
+async def connect_to_mongo():
+    global client
+    client = AsyncIOMotorClient(MONGO_URI)
+
+async def close_mongo_connection():
+    client.close()
+
+async def get_database():
+    return get_client()[DATABASE_NAME]
+

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,0 +1,4 @@
+from . import forms
+
+routers = [forms.router]
+

--- a/backend/app/routes/forms.py
+++ b/backend/app/routes/forms.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+# Placeholder endpoints
+@router.get("/")
+async def list_forms():
+    return {"forms": []}
+
+@router.post("/")
+async def create_form():
+    return {"message": "form created"}
+

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,0 +1,2 @@
+from .form import Form, Question
+

--- a/backend/app/schemas/form.py
+++ b/backend/app/schemas/form.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel
+from typing import List, Optional
+
+class Question(BaseModel):
+    text: str
+    type: str  # e.g., text, select, rating, boolean
+    options: Optional[List[str]] = None
+
+class Form(BaseModel):
+    id: Optional[str]
+    name: str
+    version: int
+    questions: List[Question]
+

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI
+from app.db.mongodb import connect_to_mongo, close_mongo_connection
+from app.routes import forms
+
+app = FastAPI(title="Simple Form Builder")
+
+@app.on_event("startup")
+async def startup_db_client():
+    await connect_to_mongo()
+
+@app.on_event("shutdown")
+async def shutdown_db_client():
+    await close_mongo_connection()
+
+app.include_router(forms.router, prefix="/forms", tags=["forms"])
+
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+motor
+pydantic

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Simple Form</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "simple-form-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-hook-form": "^7.45.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^4.0.0"
+  }
+}
+

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+function App() {
+  return (
+    <div>
+      <h1>Simple Form Builder</h1>
+    </div>
+  )
+}
+
+export default App
+

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)
+

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}
+

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}
+

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000,
+  }
+})
+


### PR DESCRIPTION
## Summary
- scaffold FastAPI backend with MongoDB connection
- add placeholder routes and schemas
- scaffold React frontend using Vite and React Hook Form
- document project setup in README
- add Python/Node `.gitignore`

## Testing
- `python3 -m py_compile backend/main.py backend/app/db/mongodb.py backend/app/routes/forms.py backend/app/__init__.py backend/app/db/__init__.py backend/app/routes/__init__.py backend/app/schemas/__init__.py backend/app/schemas/form.py`
