### PR TITLE
Add form creation support

### DIFF
--- a/backend/app/routes/forms.py
+++ b/backend/app/routes/forms.py
@@ -1,4 +1,6 @@
 from fastapi import APIRouter
+from app.schemas.form import FormSchema
+from app.db.mongo import db
 
 router = APIRouter()
 
@@ -8,6 +10,7 @@ async def list_forms():
     return {"forms": []}
 
 @router.post("/")
-async def create_form():
-    return {"message": "form created"}
+async def create_form(form: FormSchema):
+    result = await db.forms.insert_one(form.dict(exclude_none=True))
+    return {"id": str(result.inserted_id)}
 

--- a/backend/app/schemas/form.py
+++ b/backend/app/schemas/form.py
@@ -1,14 +1,13 @@
 from pydantic import BaseModel
 from typing import List, Optional
 
-class Question(BaseModel):
-    text: str
+class QuestionSchema(BaseModel):
+    label: str
     type: str  # e.g., text, select, rating, boolean
     options: Optional[List[str]] = None
 
-class Form(BaseModel):
-    id: Optional[str]
+class FormSchema(BaseModel):
+    id: Optional[str] = None
     name: str
-    version: int
-    questions: List[Question]
+    questions: List[QuestionSchema]
 


### PR DESCRIPTION
## Summary
- update backend schemas to use `label` field
- implement POST /forms endpoint to insert forms into MongoDB
- align frontend form builder with `label` field and show inserted ID

## Testing
- `python -m py_compile backend/app/**/*.py`
- `pytest -q` *(fails: command not found)*
- `npm run build` *(fails: vite not found)*